### PR TITLE
HMX: add scarthgap compatibility and update HMX config

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -15,4 +15,4 @@ BBFILES_DYNAMIC += "\
  "
 
 LAYERDEPENDS_meta-mobility-c1-distro = "core"
-LAYERSERIES_COMPAT_meta-mobility-c1-distro = "kirkstone mickledore"
+LAYERSERIES_COMPAT_meta-mobility-c1-distro = "kirkstone mickledore scarthgap"

--- a/conf/templates/hmx/bblayers.conf.sample
+++ b/conf/templates/hmx/bblayers.conf.sample
@@ -15,21 +15,26 @@ BBLAYERS = " \
   ${BSPDIR}/sources/meta-openembedded/meta-gnome \
   ${BSPDIR}/sources/meta-openembedded/meta-filesystems \
   \
+  ${BSPDIR}/sources/meta-qt5 \
+  ${BSPDIR}/sources/meta-swupdate \
+  ${BSPDIR}/sources/meta-virtualization \
+  \
   ${BSPDIR}/sources/meta-freescale \
   ${BSPDIR}/sources/meta-freescale-3rdparty \
   ${BSPDIR}/sources/meta-freescale-distro \
-  ${BSPDIR}/sources/meta-freescale-ml \
   \
-  ${BSPDIR}/sources/meta-qt5 \
-  ${BSPDIR}/sources/meta-python2 \
-  ${BSPDIR}/sources/meta-swupdate \
-  ${BSPDIR}/sources/meta-virtualization \
-  ${BSPDIR}/sources/meta-variscite-bsp \
+  ${BSPDIR}/sources/meta-imx/meta-imx-bsp \
+  ${BSPDIR}/sources/meta-nxp-connectivity/meta-nxp-openthread \
+  \
+  ${BSPDIR}/sources/meta-variscite-bsp-common \
+  ${BSPDIR}/sources/meta-variscite-bsp-imx \
+  ${BSPDIR}/sources/meta-variscite-sdk-common \
   ${BSPDIR}/sources/meta-variscite-hab \
   \
+  ${BSPDIR}/sources/meta-arm/meta-arm \
+  ${BSPDIR}/sources/meta-arm/meta-arm-toolchain \
   \
   ${BSPDIR}/sources/meta-hostmobility-bsp \
   ${BSPDIR}/sources/meta-mobility-poky-distro \
   ${BSPDIR}/sources/meta-mobility-c1-distro  \
 "
-

--- a/conf/templates/hmx/local.conf.sample
+++ b/conf/templates/hmx/local.conf.sample
@@ -25,6 +25,7 @@ ACCEPT_FSL_EULA = "1"
 INHERIT += "rm_work deploy_mobility"
 
 DISTRO_FEATURES:append = " systemd"
+DISTRO_FEATURES:append = " usrmerge"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""

--- a/recipes-bsp/u-boot/u-boot-variscite/0005-Add-autoboot-key-configuration.patch
+++ b/recipes-bsp/u-boot/u-boot-variscite/0005-Add-autoboot-key-configuration.patch
@@ -1,25 +1,31 @@
-From 4381955a54614ab0aeb5f9bb81cab7306eeaf6ef Mon Sep 17 00:00:00 2001
+From b02b24b3b9b99be7a8050181ecd8e347cf6dea4c Mon Sep 17 00:00:00 2001
 From: Andreas Ternstedt <a.ternstedt@setek.se>
-Date: Fri, 2 May 2025 11:34:13 +0000
-Subject: [PATCH 5/5] Add autoboot key configuration
+Date: Tue, 4 Nov 2025 15:17:32 +0100
+Subject: [PATCH 5/5] imx8mp_var_dart: secure autoboot by disabling keyboard interrupt
+
+Set CONFIG_AUTOBOOT_KEYED=y with empty stop string to prevent
+unauthorized U-Boot console access via keyboard interrupt.
+
+Co-developed-by: Albin Söderqvist <albin@albinutils.se>
+Signed-off-by: Andreas Ternstedt <a.ternstedt@setek.se>
 
 ---
  configs/imx8mp_var_dart_defconfig | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/configs/imx8mp_var_dart_defconfig b/configs/imx8mp_var_dart_defconfig
-index 83e24c254bc..c682fb952b4 100644
+index a3d7f568a91..14df37414db 100644
 --- a/configs/imx8mp_var_dart_defconfig
 +++ b/configs/imx8mp_var_dart_defconfig
-@@ -35,6 +35,8 @@ CONFIG_LEGACY_IMAGE_FORMAT=y
- CONFIG_OF_BOARD_SETUP=y
- CONFIG_OF_SYSTEM_SETUP=y
- CONFIG_BOOTDELAY=0
+@@ -13,6 +13,8 @@ CONFIG_SYS_I2C_MXC_I2C2=y
+ CONFIG_SYS_I2C_MXC_I2C3=y
+ CONFIG_SYS_I2C_MXC_I2C4=y
+ CONFIG_DM_GPIO=y
 +CONFIG_AUTOBOOT_KEYED=y
 +CONFIG_AUTOBOOT_STOP_STR=""
- CONFIG_BOOTCOMMAND="run bsp_bootcmd"
- CONFIG_DEFAULT_FDT_FILE="imx8mp-var-dart-dt8mcustomboard.dtb"
- CONFIG_BOARD_EARLY_INIT_F=y
+ CONFIG_DEFAULT_DEVICE_TREE="imx8mp-var-dart-dt8mcustomboard"
+ CONFIG_SPL_TEXT_BASE=0x920000
+ CONFIG_TARGET_IMX8MP_VAR_DART=y
 -- 
 2.34.1
 


### PR DESCRIPTION
Enable scarthgap in LAYERSERIES_COMPAT.

HMX updates:
- Add meta-imx-bsp, meta-nxp-connectivity, variscite, and meta-arm layers
- Remove meta-freescale-ml and meta-python2
- Enable usrmerge distro feature
- Update u-boot autoboot security patch