### PR TITLE
BBMASK meta-mobility-poky-distro/recipes-libraries/onnxruntime.bbappend

### DIFF
--- a/conf/templates/hmx/local.conf.sample
+++ b/conf/templates/hmx/local.conf.sample
@@ -41,3 +41,5 @@ DISTRO_FEED_ARCHS += "all ${PACKAGE_EXTRA_ARCHS} ${MACHINE_ARCH}"
 ERROR_QA:remove = "version-going-backwards"
 
 DL_DIR ?= "${BSPDIR}/downloads/"
+
+BBMASK += "meta-mobility-poky-distro/recipes-libraries/onnxruntime"


### PR DESCRIPTION
this layer does not use meta-imx-sdk