### PR TITLE
BBMASK OpenSSL 3.2 

### DIFF
--- a/conf/templates/hmx/local.conf.sample
+++ b/conf/templates/hmx/local.conf.sample
@@ -41,3 +41,5 @@ DISTRO_FEED_ARCHS += "all ${PACKAGE_EXTRA_ARCHS} ${MACHINE_ARCH}"
 ERROR_QA:remove = "version-going-backwards"
 
 DL_DIR ?= "${BSPDIR}/downloads/"
+# meta-imx scarthgap append targets OpenSSL 3.2, but this build uses OpenSSL 3.5.
+BBMASK += ".*/meta-imx.*/recipes-connectivity/openssl/openssl_3\.2\..*\.bbappend"

--- a/recipes-images/images/c1-image.bb
+++ b/recipes-images/images/c1-image.bb
@@ -64,7 +64,7 @@ IMAGE_INSTALL:append:imx8mp-var-dart = " \
     ethtool \
 "
 
-BBMASK = "meta-variscite-imx/recipes-core/systemd/systemd_%.bbappend"
+BBMASK += "meta-variscite-imx/recipes-core/systemd/systemd_%.bbappend"
 
 IMAGE_DEV_MANAGER   = "udev"
 IMAGE_INIT_MANAGER  = "systemd"


### PR DESCRIPTION
This makes BBMASK adjustments to enable building with later version of poky/oe layers.

It implements similar changes as in the meta-mobility-poky-distro.